### PR TITLE
pdf.py: StringIO() -> BytesIO() in python3 seems to work fine

### DIFF
--- a/xournal_converters/pdf.py
+++ b/xournal_converters/pdf.py
@@ -5,16 +5,19 @@ from reportlab.pdfgen import canvas
 from reportlab.lib.colors import toColor, Color
 from reportlab.pdfbase._fontdata import standardFonts
 from reportlab.lib.utils import ImageReader
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import BytesIO
 from base64 import b64decode
 from PyPDF2 import PdfFileReader, PdfFileWriter
 import gzip, sys, os.path, click
 
 
 def main():
+    try:                               # Python 3 is default
+        from io import BytesIO
+        dest = BytesIO()
+    except ImportError:                # Fallback to Python 2.7
+        from StringIO import StringIO
+        dest = StringIO()
+
     # fetch path
     parser = ArgumentParser()
     parser.add_argument('src')
@@ -25,7 +28,7 @@ def main():
         xml = ElementTree(file=fp)
 
     # render PDF
-    dest = BytesIO()
+    # dest = BytesIO() # --> moved to import preambule
     c = canvas.Canvas(dest, bottomup=0)
     warnings = []
     pdf_background_filename = None

--- a/xournal_converters/pdf.py
+++ b/xournal_converters/pdf.py
@@ -5,7 +5,10 @@ from reportlab.pdfgen import canvas
 from reportlab.lib.colors import toColor, Color
 from reportlab.pdfbase._fontdata import standardFonts
 from reportlab.lib.utils import ImageReader
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import BytesIO
 from base64 import b64decode
 from PyPDF2 import PdfFileReader, PdfFileWriter
 import gzip, sys, os.path, click
@@ -22,7 +25,7 @@ def main():
         xml = ElementTree(file=fp)
 
     # render PDF
-    dest = StringIO()
+    dest = BytesIO()
     c = canvas.Canvas(dest, bottomup=0)
     warnings = []
     pdf_background_filename = None
@@ -172,9 +175,9 @@ def main():
 
     # print warnings
     if warnings:
-        print >> sys.stderr, "WARNINGS:"
+        sys.stderr.write( "WARNINGS:\n" )
         for line in warnings:
-            print >> sys.stderr, " -", line
+            sys.stderr.write(" -"+line+"\n")
 
     # print PDF
     stdout = click.get_binary_stream('stdout')


### PR DESCRIPTION
Running:

python pdf.py file.xoj > file.pdf

in pyton3.6 environment produces a nice pdf-file.


Corresponding change for html.py now executes w/o errors, but produces empty html due to (erroneous?)  xml-read.

